### PR TITLE
Add PKCS#12 generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Create a PKCS#12 (PFX) file:
     $ 2cca p12 cn=example.org
 ```
 
-Line 1, 2 above is optional, just make sure that a password in the
-`CA_P12_PASSWORD` environment variable has a password.
+Line 1, 2 above is optional, just make sure that the `CA_P12_PASSWORD`
+environment variable has a password set before invoking 2cca.
 
 Security (and lack thereof)
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Create a client named Marco located in Torino IT:
     -> Generates Marco.crt and Marco.key
 ```
 
+Create a PKCS#12 (PFX) file:
+```
+    $ read -s CA_P12_PASSWORD  # 1
+    $ export CA_P12_PASSWORD  # 2
+    $ 2cca p12 cn=example.org
+```
+
+Line 1, 2 above is optional, just make sure that a password in the
+`CA_P12_PASSWORD` environment variable has a password.
+
 Security (and lack thereof)
 ---------------------------
 
@@ -118,7 +128,6 @@ TODO
 
 - email is not handled yet
 - Need to add CRL display and revocation
-- Need to add production of P12 files
 - Need to add fancy display of all existing certs and their status
 
 -- nicolas314 - 2017-May


### PR DESCRIPTION
Add option 'p14' that generates a PKCS#12 file, with the full certificate chain.

Check https://asciinema.org/a/lulfGNxy3dOoxQa88nOtYf3s8 for a demo.

Tested with LibreSSL 3.1.3 and OpenSSL 1.1.1. Had to change certificate naming convention in order to `certhash` or `c_rehash` pick them up. As I was there I added name generation functions, and reordered the commands a little bit.

Unfortunately because of the different hashing implementation I had to add SSL version detection as well.