### PR TITLE
Add function to sign CSRs

### DIFF
--- a/2cca.py
+++ b/2cca.py
@@ -47,6 +47,14 @@ defaults = {
             'keyUsage': 'critical,digitalSignature,keyEncipherment',
             'extendedKeyUsage': 'serverAuth,clientAuth'
         }
+    },
+    'signcsr': {
+        'days': 730,
+        'extensions': {
+            'basicConstraints': 'critical,CA:false',
+            'keyUsage': 'critical,digitalSignature,keyEncipherment',
+            'extendedKeyUsage': 'serverAuth,clientAuth'
+        }
     }
 }
 
@@ -59,7 +67,9 @@ def key_name(cn):
     return "%s.key" % cn
 
 
-def csr_name(cn):
+def csr_name(cn, cfg = None):
+    if cfg and "csr" in cfg:
+        return cfg["csr"]
     return "%s.csr" % cn
 
 
@@ -210,7 +220,7 @@ def gencrt(cfg):
         cmd % {
             'ca_cert': cert_name(ca),
             'ca_key': key_name(ca),
-            'in': csr_name(cn),
+            'in': csr_name(cn, cfg),
             'out': cert_name(cn),
             'serial': generate_serial(),
             'config': config_name(cn),
@@ -250,6 +260,13 @@ def generate_identity(cfg):
     os.remove(config_name(cn))
     os.remove(csr_name(cn))
 
+def sign_csr(cfg):
+    cn = cfg['cn']
+    # Sign CSR with CA
+    gencrt(cfg)
+    # Delete temporary files
+    os.remove(config_name(cn))
+    #os.remove(csr_name(cn))
 
 def crl_show(cfg):
     print(cfg)
@@ -342,4 +359,5 @@ if __name__ == "__main__":
         'crl': crl_show,
         'revoke': revoke,
         'p12': p12,
+        'signcsr': sign_csr,
     }[sys.argv[1]](get_config(sys.argv[1:]))

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Both versions are MIT-licensed.
 Usage:
 
 ```
-2cca root 
+2cca root
     Create a root CA
     You need to give it a name with CN=NAME
     You may also want to specify:
@@ -59,6 +59,13 @@ Usage:
     multiple times, like:
 
     2cca www CA=RootCA CN=www.example.com alt=www.example.com alt=example.com
+
+2cca signcsr
+    Sign a Certificate Signing Request, and create a server certificate.
+    Specify the CSR file with CSR=myrequest.csr, provide the CN, and do not
+    forget to specify the signing CA.
+
+    2cca signcsr CA=RootCA CN=www.example.com CSR=www_example_com.csr
 
 If you want to have spaces inside values, use double quotes around options:
     2cca root "CN=My Root CA" "O=Bozzos Inc."
@@ -131,4 +138,3 @@ TODO
 - Need to add fancy display of all existing certs and their status
 
 -- nicolas314 - 2017-May
-


### PR DESCRIPTION
I needed to test some software that created its own keys, and a certificate signing request alongside with it. So I added a function so sign that CSR, instead of creating the key pair from scratch. 

Right now, you still need to provide the CN on the command line. It might make sense to have 2cca figure that one out by itself. Should that be added in as well?